### PR TITLE
[FEAT] User 관련 연관관계 변경 및 Date 테이블 추가

### DIFF
--- a/.idea/shelf/Uncommitted_changes_before_Update_at_7_30_25,_1_57 PM_[Changes]/shelved.patch
+++ b/.idea/shelf/Uncommitted_changes_before_Update_at_7_30_25,_1_57 PM_[Changes]/shelved.patch
@@ -1,0 +1,108 @@
+Index: .idea/workspace.xml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.BaseRevisionTextPatchEP
+<+><?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<project version=\"4\">\n  <component name=\"AutoImportSettings\">\n    <option name=\"autoReloadType\" value=\"SELECTIVE\" />\n  </component>\n  <component name=\"ChangeListManager\">\n    <list default=\"true\" id=\"d135d69a-4b2b-4d7f-8d7b-db196cab1204\" name=\"Changes\" comment=\"\">\n      <change beforePath=\"$PROJECT_DIR$/.idea/.gitignore\" beforeDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/.idea/4th-MVP-ATORY-Server.iml\" beforeDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/.idea/misc.xml\" beforeDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/.idea/modules.xml\" beforeDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/.idea/vcs.xml\" beforeDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/.gitattributes\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/.gitattributes\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/.gitignore\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/.gitignore\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/build.gradle\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/build.gradle\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/gradle/wrapper/gradle-wrapper.jar\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/gradle/wrapper/gradle-wrapper.jar\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/gradle/wrapper/gradle-wrapper.properties\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/gradle/wrapper/gradle-wrapper.properties\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/gradlew\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/gradlew\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/gradlew.bat\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/gradlew.bat\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/settings.gradle\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/settings.gradle\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/src/main/java/ATORY/main/MainApplication.java\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/src/main/java/ATORY/atory/MainApplication.java\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/src/main/resources/application.properties\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/src/main/resources/application.properties\" afterDir=\"false\" />\n      <change beforePath=\"$PROJECT_DIR$/main/src/test/java/ATORY/main/MainApplicationTests.java\" beforeDir=\"false\" afterPath=\"$PROJECT_DIR$/project-root/src/test/java/ATORY/atory/MainApplicationTests.java\" afterDir=\"false\" />\n    </list>\n    <option name=\"SHOW_DIALOG\" value=\"false\" />\n    <option name=\"HIGHLIGHT_CONFLICTS\" value=\"true\" />\n    <option name=\"HIGHLIGHT_NON_ACTIVE_CHANGELIST\" value=\"false\" />\n    <option name=\"LAST_RESOLUTION\" value=\"IGNORE\" />\n  </component>\n  <component name=\"ExternalProjectsData\">\n    <projectState path=\"$PROJECT_DIR$\">\n      <ProjectState />\n    </projectState>\n    <projectState path=\"$PROJECT_DIR$/project-root\">\n      <ProjectState />\n    </projectState>\n  </component>\n  <component name=\"ExternalProjectsManager\">\n    <system id=\"GRADLE\">\n      <state>\n        <task path=\"$PROJECT_DIR$\">\n          <activation />\n        </task>\n        <task path=\"$PROJECT_DIR$/project-root\">\n          <activation />\n        </task>\n        <projects_view>\n          <tree_state>\n            <expand />\n            <select />\n          </tree_state>\n        </projects_view>\n      </state>\n    </system>\n  </component>\n  <component name=\"Git.Settings\">\n    <option name=\"RECENT_GIT_ROOT_PATH\" value=\"$PROJECT_DIR$\" />\n  </component>\n  <component name=\"ProjectColorInfo\">{\n  &quot;customColor&quot;: &quot;&quot;,\n  &quot;associatedIndex&quot;: 0\n}</component>\n  <component name=\"ProjectId\" id=\"30XF3LwK6AaCQslJmCYMpP4Of8S\" />\n  <component name=\"ProjectViewState\">\n    <option name=\"hideEmptyMiddlePackages\" value=\"true\" />\n    <option name=\"showLibraryContents\" value=\"true\" />\n  </component>\n  <component name=\"PropertiesComponent\"><![CDATA[{\n  \"keyToString\": {\n    \"Gradle.4th-MVP-ATORY-Server [dependencies].executor\": \"Run\",\n    \"Gradle.Build project-root.executor\": \"Run\",\n    \"RequestMappingsPanelOrder0\": \"0\",\n    \"RequestMappingsPanelOrder1\": \"1\",\n    \"RequestMappingsPanelWidth0\": \"75\",\n    \"RequestMappingsPanelWidth1\": \"75\",\n    \"RunOnceActivity.ShowReadmeOnStart\": \"true\",\n    \"Spring Boot.MainApplication.executor\": \"Run\",\n    \"git-widget-placeholder\": \"main\",\n    \"kotlin-language-version-configured\": \"true\",\n    \"last_opened_file_path\": \"/Users/judohyeon/workspace/4th-MVP-ATORY-Server\",\n    \"node.js.detected.package.eslint\": \"true\",\n    \"node.js.detected.package.tslint\": \"true\",\n    \"node.js.selected.package.eslint\": \"(autodetect)\",\n    \"node.js.selected.package.tslint\": \"(autodetect)\",\n    \"nodejs_package_manager_path\": \"npm\",\n    \"project.structure.last.edited\": \"Project\",\n    \"project.structure.proportion\": \"0.0\",\n    \"project.structure.side.proportion\": \"0.0\",\n    \"settings.editor.selected.configurable\": \"reference.settingsdialog.project.gradle\",\n    \"vue.rearranger.settings.migration\": \"true\"\n  }\n}]]></component>\n  <component name=\"RecentsManager\">\n    <key name=\"MoveFile.RECENT_KEYS\">\n      <recent name=\"$PROJECT_DIR$\" />\n      <recent name=\"$PROJECT_DIR$/project-root/src/main/resources\" />\n      <recent name=\"$PROJECT_DIR$/project-root/src/main/java/ATORY\" />\n    </key>\n  </component>\n  <component name=\"RunManager\">\n    <configuration name=\"4th-MVP-ATORY-Server [dependencies]\" type=\"GradleRunConfiguration\" factoryName=\"Gradle\" temporary=\"true\">\n      <ExternalSystemSettings>\n        <option name=\"executionName\" />\n        <option name=\"externalProjectPath\" value=\"$PROJECT_DIR$\" />\n        <option name=\"externalSystemIdString\" value=\"GRADLE\" />\n        <option name=\"scriptParameters\" value=\"--stacktrace\" />\n        <option name=\"taskDescriptions\">\n          <list />\n        </option>\n        <option name=\"taskNames\">\n          <list>\n            <option value=\"dependencies\" />\n          </list>\n        </option>\n        <option name=\"vmOptions\" />\n      </ExternalSystemSettings>\n      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>\n      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>\n      <DebugAllEnabled>false</DebugAllEnabled>\n      <RunAsTest>false</RunAsTest>\n      <method v=\"2\" />\n    </configuration>\n    <configuration name=\"MainApplication\" type=\"SpringBootApplicationConfigurationType\" factoryName=\"Spring Boot\" nameIsGenerated=\"true\">\n      <module name=\"main.main\" />\n      <option name=\"SPRING_BOOT_MAIN_CLASS\" value=\"ATORY.main.MainApplication\" />\n      <method v=\"2\">\n        <option name=\"Make\" enabled=\"true\" />\n      </method>\n    </configuration>\n    <recent_temporary>\n      <list>\n        <item itemvalue=\"Gradle.4th-MVP-ATORY-Server [dependencies]\" />\n      </list>\n    </recent_temporary>\n  </component>\n  <component name=\"SharedIndexes\">\n    <attachedChunks>\n      <set>\n        <option value=\"bundled-jdk-9f38398b9061-18abd8497189-intellij.indexing.shared.core-IU-241.14494.240\" />\n        <option value=\"bundled-js-predefined-1d06a55b98c1-74d2a5396914-JavaScript-IU-241.14494.240\" />\n      </set>\n    </attachedChunks>\n  </component>\n  <component name=\"SpellCheckerSettings\" RuntimeDictionaries=\"0\" Folders=\"0\" CustomDictionaries=\"0\" DefaultDictionary=\"application-level\" UseSingleDictionary=\"true\" transferred=\"true\" />\n  <component name=\"TaskManager\">\n    <task active=\"true\" id=\"Default\" summary=\"Default task\">\n      <changelist id=\"d135d69a-4b2b-4d7f-8d7b-db196cab1204\" name=\"Changes\" comment=\"\" />\n      <created>1753765812382</created>\n      <option name=\"number\" value=\"Default\" />\n      <option name=\"presentableId\" value=\"Default\" />\n      <updated>1753765812382</updated>\n      <workItem from=\"1753765813295\" duration=\"751000\" />\n      <workItem from=\"1753766572767\" duration=\"2193000\" />\n      <workItem from=\"1753770088932\" duration=\"29000\" />\n      <workItem from=\"1753770139196\" duration=\"26000\" />\n      <workItem from=\"1753770181290\" duration=\"409000\" />\n      <workItem from=\"1753770846096\" duration=\"315000\" />\n      <workItem from=\"1753771216710\" duration=\"394000\" />\n      <workItem from=\"1753771623781\" duration=\"108000\" />\n      <workItem from=\"1753771743542\" duration=\"49000\" />\n      <workItem from=\"1753771872543\" duration=\"167000\" />\n      <workItem from=\"1753772050628\" duration=\"788000\" />\n    </task>\n    <servers />\n  </component>\n  <component name=\"TypeScriptGeneratedFilesManager\">\n    <option name=\"version\" value=\"3\" />\n  </component>\n</project>
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/.idea/workspace.xml b/.idea/workspace.xml
+--- a/.idea/workspace.xml	(revision 150f6b08bfecea8e71f55969530022cf5ea7a530)
++++ b/.idea/workspace.xml	(date 1753851465953)
+@@ -4,24 +4,7 @@
+     <option name="autoReloadType" value="SELECTIVE" />
+   </component>
+   <component name="ChangeListManager">
+-    <list default="true" id="d135d69a-4b2b-4d7f-8d7b-db196cab1204" name="Changes" comment="">
+-      <change beforePath="$PROJECT_DIR$/.idea/.gitignore" beforeDir="false" />
+-      <change beforePath="$PROJECT_DIR$/.idea/4th-MVP-ATORY-Server.iml" beforeDir="false" />
+-      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" />
+-      <change beforePath="$PROJECT_DIR$/.idea/modules.xml" beforeDir="false" />
+-      <change beforePath="$PROJECT_DIR$/.idea/vcs.xml" beforeDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/.gitattributes" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/.gitattributes" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/.gitignore" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/build.gradle" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/gradle/wrapper/gradle-wrapper.jar" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/gradle/wrapper/gradle-wrapper.jar" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/gradle/wrapper/gradle-wrapper.properties" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/gradle/wrapper/gradle-wrapper.properties" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/gradlew" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/gradlew" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/gradlew.bat" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/gradlew.bat" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/settings.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/settings.gradle" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/src/main/java/ATORY/main/MainApplication.java" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/src/main/java/ATORY/atory/MainApplication.java" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/src/main/resources/application.properties" afterDir="false" />
+-      <change beforePath="$PROJECT_DIR$/main/src/test/java/ATORY/main/MainApplicationTests.java" beforeDir="false" afterPath="$PROJECT_DIR$/project-root/src/test/java/ATORY/atory/MainApplicationTests.java" afterDir="false" />
+-    </list>
++    <list default="true" id="d135d69a-4b2b-4d7f-8d7b-db196cab1204" name="Changes" comment="" />
+     <option name="SHOW_DIALOG" value="false" />
+     <option name="HIGHLIGHT_CONFLICTS" value="true" />
+     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+@@ -61,35 +44,38 @@
+   &quot;associatedIndex&quot;: 0
+ }</component>
+   <component name="ProjectId" id="30XF3LwK6AaCQslJmCYMpP4Of8S" />
++  <component name="ProjectLevelVcsManager">
++    <ConfirmationsSetting value="1" id="Add" />
++  </component>
+   <component name="ProjectViewState">
+     <option name="hideEmptyMiddlePackages" value="true" />
+     <option name="showLibraryContents" value="true" />
+   </component>
+-  <component name="PropertiesComponent"><![CDATA[{
+-  "keyToString": {
+-    "Gradle.4th-MVP-ATORY-Server [dependencies].executor": "Run",
+-    "Gradle.Build project-root.executor": "Run",
+-    "RequestMappingsPanelOrder0": "0",
+-    "RequestMappingsPanelOrder1": "1",
+-    "RequestMappingsPanelWidth0": "75",
+-    "RequestMappingsPanelWidth1": "75",
+-    "RunOnceActivity.ShowReadmeOnStart": "true",
+-    "Spring Boot.MainApplication.executor": "Run",
+-    "git-widget-placeholder": "main",
+-    "kotlin-language-version-configured": "true",
+-    "last_opened_file_path": "/Users/judohyeon/workspace/4th-MVP-ATORY-Server",
+-    "node.js.detected.package.eslint": "true",
+-    "node.js.detected.package.tslint": "true",
+-    "node.js.selected.package.eslint": "(autodetect)",
+-    "node.js.selected.package.tslint": "(autodetect)",
+-    "nodejs_package_manager_path": "npm",
+-    "project.structure.last.edited": "Project",
+-    "project.structure.proportion": "0.0",
+-    "project.structure.side.proportion": "0.0",
+-    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+-    "vue.rearranger.settings.migration": "true"
++  <component name="PropertiesComponent">{
++  &quot;keyToString&quot;: {
++    &quot;Gradle.4th-MVP-ATORY-Server [dependencies].executor&quot;: &quot;Run&quot;,
++    &quot;Gradle.Build project-root.executor&quot;: &quot;Run&quot;,
++    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
++    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
++    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
++    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
++    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
++    &quot;Spring Boot.MainApplication.executor&quot;: &quot;Run&quot;,
++    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
++    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
++    &quot;last_opened_file_path&quot;: &quot;/Users/judohyeon/workspace/4th-MVP-ATORY-Server&quot;,
++    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
++    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
++    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
++    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
++    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
++    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
++    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
++    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
++    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
++    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+   }
+-}]]></component>
++}</component>
+   <component name="RecentsManager">
+     <key name="MoveFile.RECENT_KEYS">
+       <recent name="$PROJECT_DIR$" />
+@@ -97,7 +83,7 @@
+       <recent name="$PROJECT_DIR$/project-root/src/main/java/ATORY" />
+     </key>
+   </component>
+-  <component name="RunManager">
++  <component name="RunManager" selected="Gradle.4th-MVP-ATORY-Server [dependencies]">
+     <configuration name="4th-MVP-ATORY-Server [dependencies]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+       <ExternalSystemSettings>
+         <option name="executionName" />

--- a/.idea/shelf/Uncommitted_changes_before_Update_at_7_30_25__1_57PM__Changes_.xml
+++ b/.idea/shelf/Uncommitted_changes_before_Update_at_7_30_25__1_57PM__Changes_.xml
@@ -1,0 +1,4 @@
+<changelist name="Uncommitted_changes_before_Update_at_7_30_25,_1_57 PM_[Changes]" date="1753851478642" recycled="false" toDelete="true">
+  <option name="PATH" value="$PROJECT_DIR$/.idea/shelf/Uncommitted_changes_before_Update_at_7_30_25,_1_57 PM_[Changes]/shelved.patch" />
+  <option name="DESCRIPTION" value="Uncommitted changes before Update at 7/30/25, 1:57 PM [Changes]" />
+</changelist>

--- a/project-root/src/main/java/ATORY/atory/domain/artist/entity/Artist.java
+++ b/project-root/src/main/java/ATORY/atory/domain/artist/entity/Artist.java
@@ -16,8 +16,8 @@ public class Artist {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
 
     private String birth;

--- a/project-root/src/main/java/ATORY/atory/domain/collector/entity/Collector.java
+++ b/project-root/src/main/java/ATORY/atory/domain/collector/entity/Collector.java
@@ -16,8 +16,8 @@ public class Collector {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
 
     private String birth;

--- a/project-root/src/main/java/ATORY/atory/domain/gallery/entity/Gallery.java
+++ b/project-root/src/main/java/ATORY/atory/domain/gallery/entity/Gallery.java
@@ -16,8 +16,8 @@ public class Gallery {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
     private User user;
 
     private String name;

--- a/project-root/src/main/java/ATORY/atory/domain/post/dto/PostDateDto.java
+++ b/project-root/src/main/java/ATORY/atory/domain/post/dto/PostDateDto.java
@@ -1,0 +1,27 @@
+package ATORY.atory.domain.post.dto;
+
+import ATORY.atory.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class PostDateDto {
+    private Long id;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private Post post;
+
+    @Builder
+    public PostDateDto(Long id, Post post, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.post = post;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+}

--- a/project-root/src/main/java/ATORY/atory/domain/post/entity/PostDate.java
+++ b/project-root/src/main/java/ATORY/atory/domain/post/entity/PostDate.java
@@ -1,0 +1,35 @@
+package ATORY.atory.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Setter
+@Service
+@Table(name = "PostDate")
+public class PostDate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder
+    public PostDate(Long id, LocalDateTime createdAt, LocalDateTime modifiedAt, Post post) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.post = post;
+    }
+}

--- a/project-root/src/main/java/ATORY/atory/domain/post/repository/PostDateRepository.java
+++ b/project-root/src/main/java/ATORY/atory/domain/post/repository/PostDateRepository.java
@@ -1,0 +1,9 @@
+package ATORY.atory.domain.post.repository;
+
+import ATORY.atory.domain.post.entity.PostDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostDateRepository extends JpaRepository<PostDate, Long> {
+}


### PR DESCRIPTION
## 🧑‍💻 작업내용
<!-- 어떤 내용의 PR인가요? -->
Artist, Collector, Gallery와 User의 연관관계 ManyToOne에서 OneToOne으로 변경합니다.
유저당 하나의 역할을 선택해야 한다는 성격을 고려해 변경하였습니다.

Post의 정렬을 위해서 Date 테이블을 추가로 설계하여 Post와 연관시켜 두었습니다.
<br>

## 🌱 To Reviewers
<!-- PR을 검토할 때 확인해야 할 사항이 있나요? -->
- PostDate의 Controller와 Service 파일은 만들지 않았습니다. 필요하시면 추가해 사용해주세요.
<br>

## 💫 Issue Number
<!-- 이슈 번호를 작성해주세요 -->
Fixes #9
<br>

## 💡 Reference
<!-- 참고한 자료, 읽기 좋은 글이 있다면 링크를 달아주세요! -->
